### PR TITLE
Fix/visual error messages

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import "./App.css";
 import Movies from "../Movies/Movies";
 import MovieDetail from "../MovieDetail/MovieDetail";
 import { Routes, Route } from 'react-router-dom';
+import { getAllMovies } from '../apiCalls';
 
 function App() {
   const [movies, setMovies] = useState([]);
@@ -21,19 +22,25 @@ function App() {
     ? { backgroundImage: `url(${selectedMovie.backdrop_path})` }
     : {};
 
+    useEffect(() => {
+      getAllMovies()
+        .then((data) => setMovies(data.movies))
+        .catch((error) => {
+          console.error(error);
+          setError(`Oopsie! Something went wrong, please try again later.`);
+        });
+    }, []);
+
   return (
     <main className={`App ${selectedMovie ? "show-selected" : ""}`} style={mainStyle}>
       <header>
         <h1>Rancid Tomatillos</h1>
       </header>
+      {error && (<div className="error-message">{error}</div>)}
       <Routes>
-        <Route path="/" element={error ? (
-          <div className="error-message">{error}</div>
-        ) : (<Movies movies={movies} selectMovie={selectMovie} />)} />
+        <Route path="/" element={<Movies movies={movies} selectMovie={selectMovie} />} />
 
-        <Route path="/movies/:id" element={error ? (
-          <div className="error-message">{error}</div>
-        ) : (<MovieDetail movie={selectedMovie} clearMovieSelection={clearMovieSelection} />)} />
+        <Route path="/movies/:id" element={<MovieDetail movie={selectedMovie} clearMovieSelection={clearMovieSelection} />} />
       </Routes>
     </main>
   );

--- a/src/MovieDetail/MovieDetail.js
+++ b/src/MovieDetail/MovieDetail.js
@@ -26,9 +26,14 @@ function MovieDetail() {
     ? { backgroundImage: `url(${selectedMovie.backdrop_path})` }
     : {};
 
+  if (error) {
+    return <div className='error-message'>{error}</div>;
+  }
+
   if (!selectedMovie) {
     return <div>Loading movie details...</div>;
   }
+
   return (
     <div className={"movie-detail show-selected"} style={mainStyle}>
       <img className="poster" src={selectedMovie.poster_path} alt={`${selectedMovie.title} poster`} />


### PR DESCRIPTION
# Description
- Fix issue where friendly server error messaging was not showing up on the main page
- Fix issue where friendly server error messaging was not showing up on the detail pages

# Screenshot(s)
Main Page:
![Screenshot 2023-12-06 at 12 22 00 PM](https://github.com/rjsturing/rancid-tomatillos/assets/133910120/21b11e54-eec4-4ed6-ad04-269e389af2a5)

Detail Page:
![Screenshot 2023-12-06 at 1 01 22 PM](https://github.com/rjsturing/rancid-tomatillos/assets/133910120/69b81427-8295-4186-9ee2-9d01f49c6291)

# Notes
- This PR does not address the issue where the messaging doesn't disappear automatically when there's no longer an error. That will be investigated and addressed in a future ticket/PR.

# Checklist
- [ ] My PR has an appropriately descriptive and concise title.
- [ ] My code follows the Turing Style Guides and best practices.
- [ ] I ran the code locally and verified that there are no visible errors.
- [ ] fix: My PR clearly describes what bug I'm fixing and why.