### PR TITLE
feat: Make main page responsive for several breakpoints

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -13,15 +13,15 @@ header {
 .header-title {
   color: white;
   margin-left: -10px;
-  margin-top: 20px;
+  margin-top: 25px;
   text-shadow: 2px 2px 4px rgba(0,0,0,2);
 }
 
 .header-title h1 {
   color: white;
-  margin-top: 20px;
-  margin-bottom: 35px;
-  font-size: 75px;
+  margin-top: 0px;
+  margin-bottom: 30px;
+  font-size: 30px;
   font-family: 'elMariachi', sans-serif;
 }
 
@@ -34,14 +34,12 @@ body {
 }
 
 .logo img {
-  max-width: 75px;
+  max-width: 30px;
   margin-right: 10px;
-  margin-left: 35px;
-  margin-top: 5px;
+  margin-top: -5px;
 }
 
 h1 {
-  margin: 50;
   color: white;
 }
 
@@ -51,42 +49,52 @@ h1 {
   font-size: 2em;
 }
 
+@media screen and (min-width: 1536px) {
+  .logo img {
+    max-width: 84px;
+  }
 
-
-
-
-/* .App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
+  .header-title h1 {
+    font-size: 84px;
   }
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+@media screen and (min-width: 1280px) and (max-width: 1535px) {
+  .logo img {
+    max-width: 72px;
   }
 
-  to {
-    transform: rotate(360deg);
+  .header-title h1 {
+    font-size: 72px;
   }
-} */
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1279px) {
+  .logo img {
+    max-width: 60px;
+  }
+
+  .header-title h1 {
+    font-size: 60px;
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1023px) {
+  .logo img {
+    max-width: 48px;
+  }
+
+  .header-title h1 {
+    font-size: 48px;
+  }
+}
+
+@media screen and (min-width: 576px) and (max-width: 767px) {
+  .logo img {
+    max-width: 36px;
+  }
+
+  .header-title h1 {
+    font-size: 36px;
+  }
+}

--- a/src/Movies/Movies.css
+++ b/src/Movies/Movies.css
@@ -1,11 +1,41 @@
 .movies-container {
-  padding: 20px;
+  padding: 10px;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   grid-gap: 20px;
 }
 
 .movie-card-link {
   color: inherit;
   text-decoration: inherit;
+}
+
+@media screen and (min-width: 1536px) {
+  .movies-container {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+@media screen and (min-width: 1280px) and (max-width: 1535px) {
+  .movies-container {
+    grid-template-columns: repeat(5, 1fr);
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1279px) {
+  .movies-container {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1023px) {
+  .movies-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media screen and (min-width: 576px) and (max-width: 767px) {
+  .movies-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }


### PR DESCRIPTION
# Description
- Adjusts main page css to be mobile-first
- Adds media queries to adjust number of posters per row and header sizing based on breakpoints

# Screenshot(s)
1536px:
<img width="1187" alt="Screenshot 2023-12-09 at 10 33 28 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/133910120/c59ed66d-5b9d-43f9-baf3-52d5f6554ded">

1280px:
<img width="1190" alt="Screenshot 2023-12-09 at 10 33 49 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/133910120/2ea50428-03f0-4ac7-a7e2-3cd8e0e9f13a">

1024px:
<img width="1187" alt="Screenshot 2023-12-09 at 10 34 12 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/133910120/00f489a0-8cd3-400a-89b9-f70a68542ffc">

768px:
<img width="1189" alt="Screenshot 2023-12-09 at 10 34 31 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/133910120/f9a152ee-d133-4260-863a-b59380aa8532">

576px:
<img width="1190" alt="Screenshot 2023-12-09 at 10 34 53 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/133910120/34d5510a-bde3-4bb5-9dd5-a06ba1c3af2c">

480px:
<img width="1188" alt="Screenshot 2023-12-09 at 10 35 17 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/133910120/38b83490-0fad-4318-969f-e3e0716a945c">

# Notes
- Only makes the main page responsive, although the header will also be responsive for detail pages
  - This only includes the header and its h1; back button will need to be adjusted in detail page PR

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] feat: My PR clearly describes what feature I'm adding and any changes needed to make it work.