### PR TITLE
feat: Make detail page responsive for smaller breakpoint

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -10,6 +10,12 @@ header {
   padding-top: 10px;
 }
 
+header a,
+header a:visited {
+  text-decoration: none;
+  color: inherit;
+}
+
 .header-title {
   color: white;
   margin-left: -10px;
@@ -23,6 +29,17 @@ header {
   margin-bottom: 30px;
   font-size: 30px;
   font-family: 'elMariachi', sans-serif;
+  transition: text-shadow 0.1s ease-in-out;
+}
+
+.header-title h1:hover {
+  color: #D0A9F5;
+  text-shadow:
+    0 0 5px #278140,
+    0 0 20px #A23BEF,
+    0 0 35px #A23BEF,
+    0 0 40px #A23BEF, 
+    0 0 50px #A23BEF;
 }
 
 body {

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -41,7 +41,7 @@ function App() {
     return (
       <main className={`App ${selectedMovie ? "show-selected" : ""}`}>
         <header>
-          <Link to="/" style={{ display: 'flex', alignItems: 'center' }}>
+          <Link reloadDocument to="/" style={{ display: 'flex', alignItems: 'center' }}>
             <div className="logo">
               <img src="/tomatillo-icon.png" alt="Tomatillo Logo" />
             </div>

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -7,7 +7,7 @@ import MovieDetail from "../MovieDetail/MovieDetail";
 import { Routes, Route } from "react-router-dom";
 import { getAllMovies } from "../apiCalls";
 import '../Fonts/Fonts.css';
-
+import { Link } from 'react-router-dom';
 
 function App() {
   const [movies, setMovies] = useState([]);
@@ -38,16 +38,18 @@ function App() {
         });
     }, []);
 
-  return (
-    <main className={`App ${selectedMovie ? "show-selected" : ""}`}>
-      <header>
-        <div className="logo">
-          <img src="/tomatillo-icon.png" alt="Tomatillo Logo" />
-        </div>
-        <div className="header-title">
-          <h1>Rancid Tomatillos</h1>
-        </div>
-      </header>
+    return (
+      <main className={`App ${selectedMovie ? "show-selected" : ""}`}>
+        <header>
+          <Link to="/" style={{ display: 'flex', alignItems: 'center' }}>
+            <div className="logo">
+              <img src="/tomatillo-icon.png" alt="Tomatillo Logo" />
+            </div>
+            <div className="header-title">
+              <h1>Rancid Tomatillos</h1>
+            </div>
+          </Link>
+        </header>
       {error && <div className="error-message">{error}</div>}
       <Routes>
         <Route

--- a/src/MovieDetail/MovieDetail.css
+++ b/src/MovieDetail/MovieDetail.css
@@ -124,3 +124,26 @@
 .back-button:hover {
   background-color: rgba(65, 158, 79, 0.427);
 }
+
+@media screen and (max-width: 768px) {
+  .movie-detail {
+    flex-direction: column;
+  }
+
+  .movie-detail .left-side,
+  .movie-detail .right-side {
+    flex: none;
+    width: 100%;
+    padding-right: 0;
+    align-items: center;
+    text-align: center;
+  }
+
+  .movie-detail .right-side {
+    margin-top: 20px;
+  }
+
+  .synopsis-container {
+    text-align: left;
+  }
+}

--- a/src/MovieDetail/MovieDetail.css
+++ b/src/MovieDetail/MovieDetail.css
@@ -26,19 +26,19 @@
 }
 
 .movie-detail .right-side h2 {
-  font-size: 30px;
+  font-size: 30px; 
   font-style: italic;
   margin-bottom: 10px;
 }
 
 .movie-detail .right-side h1 {
-  font-size: 26px;
+  font-size: 26px; 
   margin-bottom: 10px;
 }
 
 .movie-detail .right-side p {
   font-size: 24px;
-  margin-bottom: 10px;
+  margin-bottom: 10px; 
 }
 
 .custom-font {
@@ -55,6 +55,11 @@
   max-height: 300px;
   overflow-y: auto;
   margin-bottom: 20px;
+  text-align: left;
+}
+
+.synopsis-container p {
+  text-align: left;
 }
 
 .movie-detail .poster {
@@ -67,27 +72,28 @@
   box-shadow: 5px 10px 20px rgba(0,0,0,.75);
 }
 
-.movie-detail img {
-  max-width: 100%;
-  border-radius: 8px;
+.movie-detail .back-button {
+  position: fixed;
+  top: 0; 
+  left: 0; 
+  z-index: 10;
+  margin-top: 60px;
+  margin-left: 50px;
 }
 
-.movie-detail .back-button {
-  position: absolute;
-  top: -130px;
-  left: 10px;
-  z-index: 10;
-  padding: 10px 20px;
-  font-size: 18px;
+.movie-detail img {
+  max-width: 100%;
+  border-radius: 8px; 
+}
+
+.back-button {
+  padding: 20px 30px;
+  font-size: 25px;
   background-color: black;
   color: white;
   border: none;
   border-radius: 5px;
   cursor: pointer;
-}
-
-.back-button:hover {
-  background-color: rgba(65, 158, 79, 0.427);
 }
 
 .show-selected {
@@ -97,8 +103,8 @@
   position: relative;
   color: white;
 }
-
-.show-selected::before {
+  
+.show-selected::before { 
   content: '';
   position: absolute;
   top: 0;
@@ -109,101 +115,12 @@
   opacity: 0.5;
   z-index: 1;
 }
-
+  
 .show-selected > * {
   position: relative;
-  z-index: 2;
+  z-index: 2; 
 }
 
-@media screen and (max-width: 1535px) {
-  .movie-detail .right-side h3 {
-    font-size: 36px;
-  }
-
-  .movie-detail .right-side h2 {
-    font-size: 28px;
-  }
-
-  .movie-detail .right-side h1,
-  .movie-detail .right-side p {
-    font-size: 22px;
-  }
-}
-
-@media screen and (max-width: 1023px) {
-  .movie-detail {
-    flex-direction: column;
-  }
-
-  .movie-detail .left-side,
-  .movie-detail .right-side {
-    flex: none;
-    width: 100%;
-  }
-
-  .movie-detail .right-side h3 {
-    font-size: 32px;
-  }
-
-  .movie-detail .right-side h2 {
-    font-size: 24px;
-  }
-
-  .movie-detail .right-side h1,
-  .movie-detail .right-side p {
-    font-size: 20px;
-  }
-
-  .movie-detail .right-side h3,
-  .movie-detail .right-side h2,
-  .movie-detail .right-side p {
-    text-align: center;
-  }
-
-  .movie-detail .right-side {
-    text-align: center;
-    align-items: center;
-  }
-
-  .back-button {
-    font-size: 35px;
-    padding: 10px 20px;
-    top: -30px;
-    left: 10px;
-  }
-}
-
-@media screen and (max-width: 767px) {
-  .movie-detail .right-side h3 {
-    font-size: 28px;
-  }
-
-  .movie-detail .right-side h2 {
-    font-size: 22px;
-  }
-
-  .movie-detail .right-side h1,
-  .movie-detail .right-side p {
-    font-size: 18px;
-  }
-
-  .back-button {
-    font-size: 20px;
-    padding: 15px 25px;
-    top: 50px;
-    left: 10px;
-  }
-}
-
-@media screen and (max-width: 576px) {
-  .movie-detail {
-    padding: 20px;
-  }
-
-  .back-button {
-    font-size: 20px;
-    padding: 15px 25px;
-    top: 20px;
-    left: 10px;
-  }
+.back-button:hover {
+  background-color: rgba(65, 158, 79, 0.427);
 }

--- a/src/MovieDetail/MovieDetail.css
+++ b/src/MovieDetail/MovieDetail.css
@@ -26,19 +26,19 @@
 }
 
 .movie-detail .right-side h2 {
-  font-size: 30px; 
+  font-size: 30px;
   font-style: italic;
   margin-bottom: 10px;
 }
 
 .movie-detail .right-side h1 {
-  font-size: 26px; 
+  font-size: 26px;
   margin-bottom: 10px;
 }
 
 .movie-detail .right-side p {
   font-size: 24px;
-  margin-bottom: 10px; 
+  margin-bottom: 10px;
 }
 
 .custom-font {
@@ -67,28 +67,27 @@
   box-shadow: 5px 10px 20px rgba(0,0,0,.75);
 }
 
-.movie-detail .back-button {
-  position: fixed;
-  top: 0; 
-  left: 0; 
-  z-index: 10;
-  margin-top: 60px;
-  margin-left: 50px;
-}
-
 .movie-detail img {
   max-width: 100%;
-  border-radius: 8px; 
+  border-radius: 8px;
 }
 
-.back-button {
-  padding: 20px 30px;
-  font-size: 25px;
+.movie-detail .back-button {
+  position: absolute;
+  top: -130px;
+  left: 10px;
+  z-index: 10;
+  padding: 10px 20px;
+  font-size: 18px;
   background-color: black;
   color: white;
   border: none;
   border-radius: 5px;
   cursor: pointer;
+}
+
+.back-button:hover {
+  background-color: rgba(65, 158, 79, 0.427);
 }
 
 .show-selected {
@@ -98,8 +97,8 @@
   position: relative;
   color: white;
 }
-  
-.show-selected::before { 
+
+.show-selected::before {
   content: '';
   position: absolute;
   top: 0;
@@ -110,12 +109,101 @@
   opacity: 0.5;
   z-index: 1;
 }
-  
+
 .show-selected > * {
   position: relative;
-  z-index: 2; 
+  z-index: 2;
 }
 
-.back-button:hover {
-  background-color: rgba(65, 158, 79, 0.427);
+@media screen and (max-width: 1535px) {
+  .movie-detail .right-side h3 {
+    font-size: 36px;
+  }
+
+  .movie-detail .right-side h2 {
+    font-size: 28px;
+  }
+
+  .movie-detail .right-side h1,
+  .movie-detail .right-side p {
+    font-size: 22px;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .movie-detail {
+    flex-direction: column;
+  }
+
+  .movie-detail .left-side,
+  .movie-detail .right-side {
+    flex: none;
+    width: 100%;
+  }
+
+  .movie-detail .right-side h3 {
+    font-size: 32px;
+  }
+
+  .movie-detail .right-side h2 {
+    font-size: 24px;
+  }
+
+  .movie-detail .right-side h1,
+  .movie-detail .right-side p {
+    font-size: 20px;
+  }
+
+  .movie-detail .right-side h3,
+  .movie-detail .right-side h2,
+  .movie-detail .right-side p {
+    text-align: center;
+  }
+
+  .movie-detail .right-side {
+    text-align: center;
+    align-items: center;
+  }
+
+  .back-button {
+    font-size: 35px;
+    padding: 10px 20px;
+    top: -30px;
+    left: 10px;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .movie-detail .right-side h3 {
+    font-size: 28px;
+  }
+
+  .movie-detail .right-side h2 {
+    font-size: 22px;
+  }
+
+  .movie-detail .right-side h1,
+  .movie-detail .right-side p {
+    font-size: 18px;
+  }
+
+  .back-button {
+    font-size: 20px;
+    padding: 15px 25px;
+    top: 50px;
+    left: 10px;
+  }
+}
+
+@media screen and (max-width: 576px) {
+  .movie-detail {
+    padding: 20px;
+  }
+
+  .back-button {
+    font-size: 20px;
+    padding: 15px 25px;
+    top: 20px;
+    left: 10px;
+  }
 }

--- a/src/MovieDetail/MovieDetail.js
+++ b/src/MovieDetail/MovieDetail.js
@@ -39,11 +39,11 @@ function MovieDetail() {
 
   return (
     <div className="movie-detail show-selected" style={mainStyle}>
-      <Link to={"/"}>
+      {/* <Link to={"/"}>
         <button className="back-button">
           <span className="custom-font">←</span>
         </button>
-      </Link>
+      </Link> */}
       <div className="left-side">
         <img
           className="poster"

--- a/src/MovieDetail/MovieDetail.js
+++ b/src/MovieDetail/MovieDetail.js
@@ -21,17 +21,6 @@ function MovieDetail() {
     }
   }, [id]);
 
-  // prevent detail page from scrolling overflow
-  useEffect(() => {
-    const originalStyle = window.getComputedStyle(document.body).overflow;
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.body.style.overflow = originalStyle;
-    };
-  }, []);
-  //
-
   const mainStyle = selectedMovie
     ? { backgroundImage: `url(${selectedMovie.backdrop_path})` }
     : {};
@@ -52,7 +41,7 @@ function MovieDetail() {
     <div className="movie-detail show-selected" style={mainStyle}>
       <Link to={"/"}>
         <button className="back-button">
-          <span className="custom-font">←ㅤBack</span>
+          <span className="custom-font">←</span>
         </button>
       </Link>
       <div className="left-side">

--- a/src/MovieDetail/MovieDetail.js
+++ b/src/MovieDetail/MovieDetail.js
@@ -39,11 +39,6 @@ function MovieDetail() {
 
   return (
     <div className="movie-detail show-selected" style={mainStyle}>
-      {/* <Link to={"/"}>
-        <button className="back-button">
-          <span className="custom-font">←</span>
-        </button>
-      </Link> */}
       <div className="left-side">
         <img
           className="poster"


### PR DESCRIPTION
# Description
- Adds media query to adjust movie poster and details based on breakpoint for smaller devices.
- Removes the back button and adds route to the header when clicked.

# Screenshot(s)
<img width="668" alt="Screenshot 2023-12-10 at 8 33 10 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/135551833/7769f774-fbee-409e-ba4c-17674a6b3e04">
<img width="671" alt="Screenshot 2023-12-10 at 8 33 27 PM" src="https://github.com/rjsturing/rancid-tomatillos/assets/135551833/1d1879d3-3773-4134-a648-5ee07f0a806d">

# Notes
I would love to change up the HTML so that the movie title and tagline are displayed before the poster on mobile devices.

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] feat: My PR clearly describes what feature I'm adding and any changes needed to make it work.